### PR TITLE
:heavy_plus_sign: Add preserveRoute config

### DIFF
--- a/projects/auth/src/lib/models.ts
+++ b/projects/auth/src/lib/models.ts
@@ -14,6 +14,7 @@ export interface AuthConfig {
   discovery?: boolean;
   clockSkewSeconds?: number;
   useHttps?: boolean;
+  preserveRoute?: boolean;
 }
 
 export interface AuthorizeUrlParams {

--- a/projects/auth/src/lib/oauth-helper.ts
+++ b/projects/auth/src/lib/oauth-helper.ts
@@ -4,6 +4,7 @@ import { sha256 } from '@identity-auth/hashing';
 import { KEYUTIL, KJUR } from 'jsrsasign';
 import { decodeJWt } from '@identity-auth/jwt';
 import { dateNowMsSinceEpoch } from './datetime-helper';
+import { getCurrentUrl, getQueryParams, getUrlWithoutParams } from './url-helper';
 
 const SKEW_DEFAULT = 0;
 
@@ -317,4 +318,18 @@ export const checkState = (localState?: string, returnedState?: string) => {
   if (!localState && returnedState) throw new Error('Missing state in storage but expected one');
 
   if (!verifyChallenge(localState!, returnedState!)) throw new Error('Invalid state');
+};
+
+export const isAuthCallback = (authConfig: AuthConfig, useState?: boolean, responseType: 'code' = 'code') => {
+  const params = getQueryParams();
+  const currentUrl = getUrlWithoutParams();
+  if (currentUrl !== authConfig.redirectUri) return false;
+  if (responseType === 'code') {
+    if (!params.has('code')) return false;
+  }
+  if (useState) {
+    if (!params.has('state')) return false;
+  }
+
+  return true;
 };

--- a/projects/auth/src/lib/url-helper.ts
+++ b/projects/auth/src/lib/url-helper.ts
@@ -2,8 +2,24 @@ export const redirectTo = (url: string) => {
   location.href = url;
 };
 
+export const replaceUrlState = (url: string) => {
+  history.replaceState({}, '', url);
+};
+
 export const getCurrentUrl = () => {
   return location.href;
+};
+
+export const getCurrentRoute = () => {
+  return location.pathname;
+};
+
+export const getCurrentOrigin = () => {
+  return location.origin;
+};
+
+export const getUrlWithoutParams = () => {
+  return getCurrentOrigin() + getCurrentRoute();
 };
 
 export const getQueryParams = () => {

--- a/src/app/auth.config.ts
+++ b/src/app/auth.config.ts
@@ -14,4 +14,5 @@ export const authConfig: AuthConfig = {
     audience: 'https://identity.com',
   },
   clockSkewSeconds: 60,
+  preserveRoute: true,
 };

--- a/src/app/login.component.ts
+++ b/src/app/login.component.ts
@@ -1,8 +1,13 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
+import { Router } from '@angular/router';
 
 @Component({
   selector: 'app-login',
   template: ``,
   standalone: true,
 })
-export class LoginComponent {}
+export class LoginComponent {
+  ngOnInit() {
+    console.log('LoginComponent.ngOnInit');
+  }
+}

--- a/src/app/test-page.component.ts
+++ b/src/app/test-page.component.ts
@@ -1,20 +1,15 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, inject, OnInit } from '@angular/core';
+import { AuthService } from '@identity-auth/core';
 
 @Component({
   selector: 'app-test-page',
-  template: `
-    <p>
-      test-page works!
-    </p>
-  `,
-  styles: [
-  ]
+  template: ` <button (click)="auth.login()">login</button>`,
+  styles: [],
 })
 export class TestPageComponent implements OnInit {
+  protected auth = inject(AuthService);
 
-  constructor() { }
+  constructor() {}
 
-  ngOnInit(): void {
-  }
-
+  ngOnInit(): void {}
 }


### PR DESCRIPTION
PreserveRoute config added.  If this is set to true then upon successful auth processing is complete, the application will redirect back to the route that initiated the login. If it is set to false, then the application will stay on the redirect uri, without the query params.